### PR TITLE
Remove constructor for Impact

### DIFF
--- a/lua-docs/content/reference/impact.yml
+++ b/lua-docs/content/reference/impact.yml
@@ -1,9 +1,10 @@
 keywords: ["particubes", "game", "mobile", "scripting", "cube", "voxel", "world"]
 type: "Impact"
-description: An Impact object can be returned when casting a ray. (see Camera.CastRay, Player.CastRay,  PointerEvent.CastRay)
 
-constructors: 
-  - description: "It's possible to create an empty Impact object with this constructor. But in general, Impact objects are obtained when casting rays."
+creatable: true
+
+blocks: 
+  - text: "An Impact object can be returned when casting a ray. (see Camera.CastRay, Player.CastRay,  PointerEvent.CastRay)"
 
 properties:
     - name: "Block"


### PR DESCRIPTION
Impact does not have a constructor, Impact objects are created when using `CastRay` function from `Player` or `Event` objects.