### PR TITLE
Fix guides to use custom colors

### DIFF
--- a/lua-docs/content/guides/quick/converting-from-default-colors.yml
+++ b/lua-docs/content/guides/quick/converting-from-default-colors.yml
@@ -1,0 +1,29 @@
+keywords: ["particubes", "game", "mobile", "scripting", "cube", "voxel", "world", "Minecraft", "Roblox", "code", "documentation", "docs"]
+title: "Quick know-how > Converting from default colors (0.0.46 -> 0.0.47)"
+blocks:
+    - text: |
+        Starting from the version 0.0.47, Particubes uses custom colors instead of default references to a fixed palette. This is why recent scripts will define colors based on the [`Color`](/reference/color) object, rather than a simple integer reference.
+
+        If you need to update one of your scripts to obey this new system, you have two solutions:
+
+        1. quick and easy: just replace your reference by `DefaultColors[<your reference>]`
+           
+           For example:
+
+    - code: |
+        -- 0.0.46
+        local BLUE = 181
+        -- 0.0.47
+        local BLUE = DefaultColors[181]
+ 
+        2. custom and efficient: define the variable with a specific RGB(A) tint by using the `Color` API and passing it 3 (RGB) or 4 (RGBA) values
+           
+           For example:
+
+    - code: |
+        local BLUE = Color(76, 215, 255)
+    
+    - text: |
+        As a reminder, here's the fixed palette that versions before 0.0.46 used:
+
+    - image: "/images/guides/pcubes-palette.png"

--- a/lua-docs/content/guides/tutorials/lone-scoundrel.yml
+++ b/lua-docs/content/guides/tutorials/lone-scoundrel.yml
@@ -212,7 +212,7 @@ blocks:
         Config = { ... }
 
         -- -----------------------
-        local BLUE = 181
+        local BLUE = Color(76, 215, 255)
         -- -----------------------
         local N_SEA_PATCH_X = 1
         local N_SEA_PATCH_Y = 1
@@ -251,9 +251,7 @@ blocks:
         The code to generate this grid is fairly short and simple overall, but it does use a few new Particubes features that need explaining:
 
         - instead of using the [`Shape`](/reference/shape) API like in [the "Tutoworld" tutorial](/guides/tutorials/tutoworld), we use the [`MutableShape`](/reference/mutableshape): this other type of object allows us to dynamically add, remove or re-color voxels of an item. It can optionally take in an item reference - this lets you load an item and edit in your game for futher customisation.
-        - when we add the block of our patch, we give it a `BLUE` colour: this value is actually the index of the blue colour in [our current map palette](/reference/map#property-localpalette), among those ones:
-
-    - image: "/images/guides/pcubes-palette.png"
+        - when we add the block of our patch, we give it a `BLUE` colour
 
     - text: |
         Re-publish the game and you'll get a little blue patch in the middle of the screen, between the avatar and the ship:
@@ -716,9 +714,9 @@ blocks:
 
     - code: |
         -- -----------------------
-        local BROWN = 43
-        local GREEN = 133
-        local BLUE = 181
+        local BROWN = Color(50, 65, 0)
+        local GREEN = Color(20, 160, 17)
+        local BLUE = Color(76, 215, 255)
         -- -----------------------
         local islands = {}
 
@@ -1000,9 +998,9 @@ blocks:
         }
 
         -- -----------------------
-        local BROWN = 43
-        local GREEN = 133
-        local BLUE = 181
+        local BROWN = Color(50, 65, 0)
+        local GREEN = Color(20, 160, 17)
+        local BLUE = Color(76, 215, 255)
         -- -----------------------
         local N_SEA_PATCH_X = 10
         local N_SEA_PATCH_Y = 10

--- a/lua-docs/content/guides/tutorials/space-race.yml
+++ b/lua-docs/content/guides/tutorials/space-race.yml
@@ -34,12 +34,22 @@ blocks:
         }
 
         ---------------------------------
-        local COLOR_WHITE = 229
-        local COLOR_RED = 55
-        local COLOR_RED_DARK = 49
-        local COLOR_GRAY = 226
-        local COLOR_GRAY_DARK = 220
-        local PLAYER_COLORS = { 31, 7, 136, 94, 52, 181, 160, 55 }
+        local COLOR_BLACK = Color(0, 0, 0)
+        local COLOR_WHITE = Color(255, 255, 255)
+        local COLOR_RED = Color(255, 50, 50)
+        local COLOR_RED_DARK = Color(150, 5, 5)
+        local COLOR_GRAY = Color(180, 180, 180)
+        local COLOR_GRAY_DARK = Color(60, 60, 60)
+        local PLAYER_COLORS = {
+            Color(255, 0, 255),
+            Color(150, 0, 180),
+            Color(10, 235, 10),
+            Color(255, 255, 0),
+            Color(255, 0, 0),
+            Color(80, 80, 255),
+            Color(120, 180, 255),
+            Color(255, 50, 50)
+        }
         local SHIP_SPEED = 240
         local BULLET_RELATIVE_SPEED = 100
         ---------------------------------
@@ -162,7 +172,7 @@ blocks:
             end
             -- add race road
             local road = MutableShape()
-            road:AddBlock(211, 0, 0, 0)
+            road:AddBlock(COLOR_BLACK, 0, 0, 0)
             road.Scale = Number3(3, 0.5, 300) * Map.LossyScale
             road.Position = Number3(p.Position.X - 7.5, -2.5, -150 * Map.LossyScale.Z)
             World:AddChild(road)
@@ -203,6 +213,9 @@ blocks:
         end
 
         function spawnBullet(p, isSpecial)
+            -- prevent bullet spamming
+            if #bullets == 3 then return end
+
             local bullet = MutableShape()
             bullet.isSpecial = isSpecial
             bullet.pID = p.ID
@@ -311,9 +324,15 @@ blocks:
                 local destroyed = false
                 if walls[b.pID] ~= nil then
                     for j, w in pairs(walls[b.pID]) do
-                        if collides(b, w) and b.isSpecial == w.isSpecial then
-                            w:RemoveFromParent()
-                            table.remove(walls[b.pID], j)
+                        if collides(b, w) then
+                            if b.isSpecial == w.isSpecial then
+                                if Player.playSolo then
+                                    score = score + 1
+                                    waitingLabel.Text = "Score: " .. score
+                                end
+                                w:RemoveFromParent()
+                                table.remove(walls[b.pID], j)
+                            end
                             b:RemoveFromParent()
                             table.remove(bullets, i)
                             destroyed = true
@@ -1350,7 +1369,7 @@ blocks:
             for _, side in pairs(plotsSpawnSides) do
                 for i = -PLOTS_N_HALF, PLOTS_N_HALF do
                     local plot = MutableShape()
-                    plot:AddBlock(211, 0, 0, 0)
+                    plot:AddBlock(COLOR_BLACK, 0, 0, 0)
                     plot.Scale = Number3(0.5, 2, 0.5) * Map.LossyScale
                     local x = p.Position.X + side * 2 * Map.LossyScale.X
                     if side == -1 then x = x - 0.5 * Map.LossyScale.X end
@@ -1443,12 +1462,22 @@ blocks:
         }
 
         ---------------------------------
-        local COLOR_WHITE = 229
-        local COLOR_RED = 55
-        local COLOR_RED_DARK = 49
-        local COLOR_GRAY = 226
-        local COLOR_GRAY_DARK = 220
-        local PLAYER_COLORS = { 31, 7, 136, 94, 52, 181, 160, 55 }
+        local COLOR_BLACK = Color(0, 0, 0)
+        local COLOR_WHITE = Color(255, 255, 255)
+        local COLOR_RED = Color(255, 50, 50)
+        local COLOR_RED_DARK = Color(150, 5, 5)
+        local COLOR_GRAY = Color(180, 180, 180)
+        local COLOR_GRAY_DARK = Color(60, 60, 60)
+        local PLAYER_COLORS = {
+            Color(255, 0, 255),
+            Color(150, 0, 180),
+            Color(10, 235, 10),
+            Color(255, 255, 0),
+            Color(255, 0, 0),
+            Color(80, 80, 255),
+            Color(120, 180, 255),
+            Color(255, 50, 50)
+        }
         local SHIP_SPEED = 210
         local BULLET_RELATIVE_SPEED = 100
         ---------------------------------
@@ -1611,7 +1640,7 @@ blocks:
             end
             -- add race road
             local road = MutableShape()
-            road:AddBlock(211, 0, 0, 0)
+            road:AddBlock(COLOR_BLACK, 0, 0, 0)
             road.Scale = Number3(3, 0.5, 300) * Map.LossyScale
             road.Position = Number3(p.Position.X - 7.5, -2.5, -150 * Map.LossyScale.Z)
             World:AddChild(road)
@@ -1626,7 +1655,7 @@ blocks:
             for _, side in pairs(plotsSpawnSides) do
                 for i = -PLOTS_N_HALF, PLOTS_N_HALF do
                     local plot = MutableShape()
-                    plot:AddBlock(211, 0, 0, 0)
+                    plot:AddBlock(COLOR_BLACK, 0, 0, 0)
                     plot.Scale = Number3(0.5, 2, 0.5) * Map.LossyScale
                     local x = p.Position.X + side * 2 * Map.LossyScale.X
                     if side == -1 then x = x - 0.5 * Map.LossyScale.X end
@@ -1667,6 +1696,8 @@ blocks:
         end
 
         function spawnBullet(p, isSpecial)
+            if #bullets == 3 then return end
+
             local bullet = MutableShape()
             bullet.isSpecial = isSpecial
             bullet.pID = p.ID
@@ -1793,9 +1824,15 @@ blocks:
                 local destroyed = false
                 if walls[b.pID] ~= nil then
                     for j, w in pairs(walls[b.pID]) do
-                        if collides(b, w) and b.isSpecial == w.isSpecial then
-                            w:RemoveFromParent()
-                            table.remove(walls[b.pID], j)
+                        if collides(b, w) then
+                            if b.isSpecial == w.isSpecial then
+                                if Player.playSolo then
+                                    score = score + 1
+                                    waitingLabel.Text = "Score: " .. score
+                                end
+                                w:RemoveFromParent()
+                                table.remove(walls[b.pID], j)
+                            end
                             b:RemoveFromParent()
                             table.remove(bullets, i)
                             destroyed = true


### PR DESCRIPTION
Updates the Lone Scoundrel and Space Race guides to use the new 0.0.47+ custom colors.

Also adds a quick how-to guide on how to convert from the "fixed colors" in 0.0.46 to the new "custom colors" in 0.0.47+.