### PR TITLE
docs : add missing image in guide 1

### DIFF
--- a/lua-docs/content/images/guides/01-tutoworld_change-world-name.png
+++ b/lua-docs/content/images/guides/01-tutoworld_change-world-name.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b1ef5baadc011bc35e7f8b3cd18c017897f13a64fea879c4348b3ac8a4360a7
+size 1445375


### PR DESCRIPTION
fixes #193 

<img width="958" alt="Screenshot 2022-10-15 at 23 05 16" src="https://user-images.githubusercontent.com/939999/196007790-bd9f6b4e-e19e-422c-b75a-1b5ff92d8349.png">
