### PR TITLE
docs : add missing image in Guide 1

### DIFF
--- a/lua-docs/content/guides/tutorials/tutoworld.yml
+++ b/lua-docs/content/guides/tutorials/tutoworld.yml
@@ -351,7 +351,7 @@ blocks:
 
         <b>Mobiles</b>
 
-    - image: "https://cu.bzh/files/5cf2be2360c68f86d8b666a54b36e831e5ca43ae.png"
+    - image: "/images/guides/01-tutoworld_action_buttons_mobile.png"
 
     - text: |
         Here, the most intuitive action to use is the `Action2`; so let's define it and, inside, call `Player:SwingRight()`:

--- a/lua-docs/content/images/guides/01-tutoworld_action_buttons_mobile.png
+++ b/lua-docs/content/images/guides/01-tutoworld_action_buttons_mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65b6774b8413b5f89a5b11f76ee4ae927e8c5f6fc9008b2c828832d2dbf5610f
+size 762905


### PR DESCRIPTION
Fixed:

<img width="1020" alt="Screenshot 2022-10-16 at 13 14 30" src="https://user-images.githubusercontent.com/939999/196032168-f36c5d7f-657a-4776-a2b2-c3e4e730229e.png">
